### PR TITLE
Fix to return current user after user creation

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -116,10 +116,7 @@ function create (client) {
         // We need to search based on the userid, since it will be unique
         return resolve(client.users.find(realm, {
           userId: uid
-        })
-          .then((user) => {
-            return user[0];
-          }));
+        }));
       });
     });
   };

--- a/test/users-test.js
+++ b/test/users-test.js
@@ -281,6 +281,33 @@ test("Test client's role user unassignment", (t) => {
   });
 });
 
+test('Test create a users', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.users.create, 'function', 'The client object returned should have a create function');
+    // Use the master realm
+    const realmName = 'master';
+
+    const testUser = {
+      username: 'a@nothing.dev',
+      firstName: 'The first name',
+      lastName: 'The last name',
+      email: 'a@nothing.dev'
+    };
+
+    // Create the user
+    return client.users.create(realmName, testUser).then((user) => {
+      // It will return the newly created user
+      t.notEqual(user.id, null, 'The id must be set on the created user');
+      t.equal(user.username, testUser.username, 'The username returned should be "a@nothing.dev"');
+      t.equal(user.firstName, testUser.firstName, 'The firstName returned should be "The first name"');
+      t.equal(user.lastName, testUser.lastName, 'The lastName returned should be "The last name"');
+      t.equal(user.email, testUser.email, 'The email returned should be "a@nothing.dev"');
+    });
+  });
+});
+
 test('Test reset password of user', (t) => {
   const kca = keycloakAdminClient(settings);
 


### PR DESCRIPTION
When creating a user it does a call to `find` to load it. Since it calls `find` with a userId it will get not an array but simply the user. So we don't need to take user[0].