### PR TITLE
fix a bug in create user

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -116,7 +116,7 @@ function create (client) {
         // We need to search based on the userid, since it will be unique
         return resolve(client.users.find(realm, {
           userId: uid
-        })
+        }));
       });
     });
   };

--- a/lib/users.js
+++ b/lib/users.js
@@ -117,9 +117,6 @@ function create (client) {
         return resolve(client.users.find(realm, {
           userId: uid
         })
-          .then((user) => {
-            return user[0];
-          }));
       });
     });
   };


### PR DESCRIPTION
At the end of create user, the code requests the user by ID, as 
> the create Endpoint returns an empty body

However the function:
```
client.users.find(realm, {
  userId: uid
})
```
resolves a single user object; not an array. As such I removed selection of user[0].