### PR TITLE
Added support for events.find REST API

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const request = require('request');
+
+const privates = require('./private-map');
+
+module.exports = {
+  find: find
+};
+
+function find (client) {
+  return function find (realmName, options) {
+    return new Promise((resolve, reject) => {
+      options = options || {};
+      const req = {
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        json: true
+      };
+
+      req.url = `${client.baseUrl}/admin/realms/${realmName}/events`;
+      req.qs = options;
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 200) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}

--- a/lib/kc-admin-client.js
+++ b/lib/kc-admin-client.js
@@ -9,6 +9,7 @@ const realms = require('./realms');
 const users = require('./users');
 const clients = require('./clients');
 const groups = require('./groups');
+const events = require('./events');
 
 function bindModule (client, input) {
   // For an
@@ -69,7 +70,8 @@ function keycloakAdminClient (settings) {
     realms: realms,
     users: users,
     clients: clients,
-    groups: groups
+    groups: groups,
+    events: events
   }));
 
   // Make baseUrl unchanging

--- a/scripts/kc-setup-for-tests.json
+++ b/scripts/kc-setup-for-tests.json
@@ -1689,7 +1689,7 @@
     "contentSecurityPolicy" : "frame-src 'self'"
   },
   "smtpServer" : { },
-  "eventsEnabled" : false,
+  "eventsEnabled" : true,
   "eventsListeners" : [ "jboss-logging" ],
   "enabledEventTypes" : [ ],
   "adminEventsEnabled" : false,

--- a/test/events-test.js
+++ b/test/events-test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('blue-tape');
+const keycloakAdminClient = require('../index');
+// const kcSetupForTests = require('../scripts/kc-setup-for-tests.json');
+
+const settings = {
+  baseUrl: 'http://127.0.0.1:8080/auth',
+  username: 'admin',
+  password: 'admin',
+  grant_type: 'password',
+  client_id: 'admin-cli'
+};
+
+test('Test getting the list of events for a Realm', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.events.find, 'function', 'The client object returned should have a events.find function');
+
+    // Use the master realm
+    const realmName = 'master';
+
+    return client.events.find(realmName).then((listOfEvents) => {
+      // The listOfCients should be an Array
+      t.equal(listOfEvents instanceof Array, true, 'the list of events should be an array');
+      /*
+      // The list of client in the master realm should have 4 people
+      t.equal(listOfClients.length, 10, 'There should be 4 client in master');
+      */
+    });
+  });
+});
+
+test("Test getting the list of events for a Realm that doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'notarealrealm';
+
+    return t.shouldFail(client.events.find(realmName), 'Realm not found.', "Realm not found should be returned if the realm wasn't found");
+  });
+});


### PR DESCRIPTION
This PR adds to the client an "events" property, on which a "find" method is available.

This allows invoking the "getEvents" REST API endpoint (as described in http://www.keycloak.org/docs-api/3.2/rest-api/index.html#_getevents).