### PR TITLE
Add support for Federated Identity APIs

### DIFF
--- a/lib/federated-identity.js
+++ b/lib/federated-identity.js
@@ -92,11 +92,6 @@ function create (client) {
         }
 
         return resolve(body);
-
-        // Since the create Endpoint returns an empty body, go get what we just imported.
-        // *** Body is empty but location header contains user id ***
-        // We need to search based on the userid, since it will be unique
-        // return resolve(client.federatedIdentity.find(realm, userId));
       });
     });
   };

--- a/lib/federated-identity.js
+++ b/lib/federated-identity.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const privates = require('./private-map');
+const request = require('request');
+
+/**
+ * @module federatedIdentity
+ */
+
+module.exports = {
+  find: find,
+  create: create,
+  remove: remove
+};
+
+/**
+  A function to get the list of social provider logins a user is associated with
+  @param {string} realmName - The name of the realm(not the realmID) - ex: master
+  @param {string} userId - The id of the user to find social logins for
+  @returns {Promise} A promise that will resolve with an Array of federated identity objects
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.federatedIdentity.find(realmName, userId)
+        .then((identityList) => {
+          console.log(identityList) // [{...},{...}, ...]
+      })
+    })
+ */
+function find (client) {
+  return function find (realm, userId) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realm}/users/${userId}/federated-identity`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 200) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to add a social provider login association for the provided user
+  @param {string} realmName - The name of the realm(not the realmID) - ex: master
+  @param {string} userId - The id of the user to add a social login for
+  @param {string} providerId - The id of the provider to add the social login association
+  @param {object} representation - The JSON representation of a federated identity - http://keycloak.github.io/docs-api/4.0/rest-api/index.html#_federatedidentityrepresentation
+  @returns {Promise} A promise that will resolve with the federated identity object
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.federatedIdentity.create(realmName, userId, providerId, representation)
+        .then(() => {
+          console.log('success')
+      })
+    })
+ */
+function create (client) {
+  return function create (realm, userId, providerId, representation) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realm}/users/${userId}/federated-identity/${providerId}`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: representation,
+        method: 'POST',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+
+        // Since the create Endpoint returns an empty body, go get what we just imported.
+        // *** Body is empty but location header contains user id ***
+        // We need to search based on the userid, since it will be unique
+        // return resolve(client.federatedIdentity.find(realm, userId));
+      });
+    });
+  };
+}
+
+/**
+  A function to delete a social provider login association for the provided user
+  @param {string} realmName - The name of the realm(not the realmID) to delete - ex: master,
+  @param {string} userId - The id of the user to remove social login association for
+  @param {string} providerId - The id of the provider to remove the social login association with
+  @returns {Promise} A promise that resolves.
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.federatedIdentity.remove(realmName, userId, providerId)
+        .then(() => {
+          console.log('success')
+      })
+    })
+ */
+function remove (client) {
+  return function remove (realmName, userId, providerId) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/users/${userId}/federated-identity/${providerId}`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        method: 'DELETE'
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        // Check that the status code is a 204
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}

--- a/lib/kc-admin-client.js
+++ b/lib/kc-admin-client.js
@@ -10,6 +10,7 @@ const users = require('./users');
 const clients = require('./clients');
 const groups = require('./groups');
 const events = require('./events');
+const federatedIdentity = require('./federated-identity');
 
 function bindModule (client, input) {
   // For an
@@ -71,7 +72,8 @@ function keycloakAdminClient (settings) {
     users: users,
     clients: clients,
     groups: groups,
-    events: events
+    events: events,
+    federatedIdentity: federatedIdentity
   }));
 
   // Make baseUrl unchanging

--- a/scripts/kc-setup-for-tests.json
+++ b/scripts/kc-setup-for-tests.json
@@ -1694,6 +1694,34 @@
   "enabledEventTypes" : [ ],
   "adminEventsEnabled" : false,
   "adminEventsDetailsEnabled" : false,
+  "identityProviders": [
+    {
+      "alias": "test-oidc",
+      "displayName": "Test Provider",
+      "internalId": "69fec1fc-0479-4dc8-9dea-b6aae98d4aaf",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": false,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "hideOnLoginPage": "",
+        "loginHint": "",
+        "validateSignature": "",
+        "clientId": "test-id",
+        "tokenUrl": "https://localhost/token",
+        "authorizationUrl": "https://localhost/auth",
+        "disableUserInfo": "",
+        "clientSecret": "**********",
+        "backchannelSupported": "",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {

--- a/test/federated-identity-test.js
+++ b/test/federated-identity-test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const test = require('blue-tape');
+const keycloakAdminClient = require('../index');
+
+const settings = {
+  baseUrl: 'http://127.0.0.1:8080/auth',
+  username: 'admin',
+  password: 'admin',
+  grant_type: 'password',
+  client_id: 'admin-cli'
+};
+
+test('Test getting the list of federated identities for a user ', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.federatedIdentity.find, 'function', 'The client object returned should have a federatedIdentity find function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = 'f9ea108b-a748-435f-9058-dab46ce59771';
+
+    return client.federatedIdentity.find(realmName, userId).then((listOfIdentities) => {
+      // The listOfIdentities should be an Array
+      t.equal(listOfIdentities instanceof Array, true, 'the list of federated identities should be an array');
+
+      // The list of identities in the master realm should be 0 for the user
+      t.equal(listOfIdentities.length, 0, 'There should be 0 federated identities for the user');
+    });
+  });
+});
+
+test('Test adding a federated identity link to a user ', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.federatedIdentity.create, 'function', 'The client object returned should have a federatedIdentity create function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = 'f9ea108b-a748-435f-9058-dab46ce59771';
+    const providerId = 'test-oidc';
+    const representation = {
+      identityProvider: 'test-oidc',
+      userId: 'ffe61c10-d3d3-4953-8587-c956d189c35a',
+      userName: 'test-user-idp'
+    };
+
+    // The create API returns an empty response, so return it and let the test handle any error
+    return client.federatedIdentity.create(realmName, userId, providerId, representation);
+  });
+});
+
+test('Test new link to a federated identity link for a user ', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+    const userId = 'f9ea108b-a748-435f-9058-dab46ce59771';
+
+    return client.federatedIdentity.find(realmName, userId).then((listOfIdentities) => {
+      // The listOfIdentities should be an Array
+      t.equal(listOfIdentities instanceof Array, true, 'the list of federated identities should be an array');
+
+      // The list of identities in the master realm should be 1 for the user
+      t.equal(listOfIdentities.length, 1, 'There should be 1 federated identity for the user');
+      t.equal(listOfIdentities[0].identityProvider, 'test-oidc', 'The identity provider of the relation should be test-oidc');
+      t.equal(listOfIdentities[0].userId, 'ffe61c10-d3d3-4953-8587-c956d189c35a', 'The userId of the federated identity should be ffe61c10-d3d3-4953-8587-c956d189c35a');
+      t.equal(listOfIdentities[0].userName, 'test-user-idp', 'The userName of the federated identity should be test-user-idp');
+    });
+  });
+});
+
+test('Test removing a federated identity link from a user ', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.federatedIdentity.remove, 'function', 'The client object returned should have a federatedIdentity remove function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = 'f9ea108b-a748-435f-9058-dab46ce59771';
+    const providerId = 'test-oidc';
+
+    // The remove API returns an empty response, so return it and let the test handle any error
+    return client.federatedIdentity.remove(realmName, userId, providerId);
+  });
+});
+
+test('Test listing the federated identities for a user', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+    const userId = 'f9ea108b-a748-435f-9058-dab46ce59771';
+
+    return client.federatedIdentity.find(realmName, userId).then((listOfIdentities) => {
+      // The listOfIdentities should be an Array
+      t.equal(listOfIdentities instanceof Array, true, 'the list of federated identities should be an array');
+
+      // The list of identities in the master realm should be 0 for the user
+      t.equal(listOfIdentities.length, 0, 'There should be 0 federated identities for the user');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for the federated identity relation APIs for listing, creating, and removing the relations.
I've updated the `master` realm with an IDP for use in the tests, and included tests for the three new functions.