### PR TITLE
perform null check before adding redirectUri and clientId query params

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -278,7 +278,7 @@ function resetPassword (c) {
   @example
   keycloakAdminClient(settings)
     .then((client) => {
-      client.users.executeActionsEmail(realmName, userId, { verifyEmail: true, updateProfile: true, updatePassword: true, configureTOTP: true })
+      client.users.executeActionsEmail(realmName, userId, { verifyEmail: true, updateProfileAction: true, updatePasswordAction: true, configureTOTPAction: true })
         .then(() => {
           console.log('success')
       })
@@ -312,8 +312,8 @@ function executeActionsEmail (c) {
       }
 
       let queryParameter = '';
-      if (options.redirectUri !== '') {
-        if (options.clientId !== '') {
+      if (options.redirectUri !== undefined && options.redirectUri !== null && options.redirectUri !== '') {
+        if (options.clientId !== undefined && options.clientId !== null && options.clientId !== '') {
           queryParameter = `?redirect_uri=${options.redirectUri}&client_id=${options.clientId}`;
         } else {
           return reject(new Error('clientId is not set but redirectUri is. Both MUST go together'));


### PR DESCRIPTION
ExecuteActionsEmail function seems to be broken when redirectUri and clientId are not present in option argument. Adding null check before appending those params to url